### PR TITLE
Checar citas antes de establecer horario

### DIFF
--- a/application/controllers/Especialistas.php
+++ b/application/controllers/Especialistas.php
@@ -9,6 +9,7 @@ class Especialistas extends BaseController{
 
         $this->load->model('SedesModel');
         $this->load->model('EspecialistasModel');
+        $this->load->model('CitasModel');
     }
 
     public function sedes(){
@@ -37,6 +38,32 @@ class Especialistas extends BaseController{
         );
 
         foreach ($period as $date) {
+            $today = new DateTime();
+            if($date < $today){
+                $response = [
+                    'status' => 'error',
+                    'message' => "No puedes cambiar un horario de un dia que ya paso.",
+                ];
+
+                $this->json($response);
+            }
+
+            $start_day = $date->format("Y-m-d 00:00:00");
+            $end_day = $date->format("Y-m-d 23:59:59");
+
+            $has_citas = $this->CitasModel->getCitasPendientes($especialista, $sede, $start_day, $end_day);
+            
+            if($has_citas){
+                $day = $date->format("Y-m-d");
+
+                $response = [
+                    'status' => 'error',
+                    'message' => "No puedes cambiar el horario el $day, por que tienes citas pendientes.",
+                ];
+
+                $this->json($response);
+            }
+
             if($sede != 0){
                 $is_ok = $this->SedesModel->addHorarioPresencial($date->format("Y-m-d"), $sede, $especialista);
             }else{

--- a/application/models/CitasModel.php
+++ b/application/models/CitasModel.php
@@ -16,4 +16,17 @@ class CitasModel extends CI_Model{
 
         return $this->db->query($query);
     }
+
+    public function getCitasPendientes($idEspecialista, $idSede, $fechaInicio, $fechaFinal){
+        $query = "SELECT *
+            FROM citas
+            LEFT JOIN atencionXSede ON citas.idAtencionXSede = atencionXSede.idAtencionXSede
+            WHERE
+                citas.idEspecialista='$idEspecialista'
+            AND citas.estatusCita IN (1)
+            AND NOT atencionXSede.idSede = '$idSede'
+            AND citas.fechaInicio BETWEEN '$fechaInicio' AND '$fechaFinal'";
+
+        return $this->db->query($query)->result_array();
+    }
 }


### PR DESCRIPTION
Hace una comprobacion si el dia seleccionado es anterior o igual a la fecha actual.
Hace una comprobacion si hay citas en estatus 1 en el rango seleccionado, por especialista, por sede.
Se mandan mensajes de error en cualquiera de los casos anteriores.