### PR TITLE
Resolución bug reagendar especialista

### DIFF
--- a/application/controllers/CalendarioController.php
+++ b/application/controllers/CalendarioController.php
@@ -397,7 +397,7 @@ class CalendarioController extends BaseController{
 				"idAtencionXSede" => intval($dataValue["idCatalogo"]),
 				"tipoCita" => $reagenda == 1 ? $dataValue['oldEventTipo'] : 3,
 				"idDetalle" => $dataValue["idDetalle"] == 0 ? NULL : $dataValue["idDetalle"],
-				"idEventoGoogle" => $reagenda == 1 ? $dataValue["idEventoGoogle"] : ''
+				"idEventoGoogle" => $reagenda == 1 && isset($dataValue["idEventoGoogle"]) ? $dataValue["idEventoGoogle"] : ''
 			];
 
 			$checkModalitie = $this->EspecialistasModel->checkModalitie($dataValue["idUsuario"], $fechaCheck);

--- a/application/models/CalendarioModel.php
+++ b/application/models/CalendarioModel.php
@@ -285,12 +285,16 @@ class CalendarioModel extends CI_Model
             OR (? BETWEEN fechaInicio AND fechaFinal))
             AND ((idPaciente = ?
             AND estatusCita IN (?, ?, ?))
-            OR (idEspecialista = ? and estatusCita IN (?, ?, ?)))",
+            OR (idEspecialista = ? and estatusCita IN (?, ?, ?))
+            OR (idPaciente = ? and estatusCita IN (?, ?, ?))
+            )",
             array(
                 $fechaInicioSuma, $fechaFinalResta,
                 $fechaInicioSuma, $fechaFinalResta,
                 $fechaInicioSuma, $fechaFinalResta,
                 $dataValue["idPaciente"],
+                1, 6, 10,
+                $dataValue["idUsuario"],
                 1, 6, 10,
                 $dataValue["idUsuario"],
                 1, 6, 10
@@ -443,7 +447,7 @@ class CalendarioModel extends CI_Model
     }
 
     public function checkInvoice($idDetalle){
-        $query = $this->ch->query("SELECT idDetalle FROM ". $this->schema_cm .".citas WHERE idDetalle = ? GROUP BY idDetalle HAVING COUNT(idDetalle) > ?", array($idDetalle, 2));
+        $query = $this->ch->query("SELECT idDetalle FROM ". $this->schema_cm .".citas WHERE idDetalle = ? AND estatus = 1 GROUP BY idDetalle HAVING COUNT(idDetalle) > ?", array($idDetalle, 2));
 
         return $query;
     }


### PR DESCRIPTION
Se corrigió el bug del especialista que pedía el idGoogleEvent al reagendar pero se validó que puede ser vació por correos de gmail. 
Se le agregó que considere sus citas propias al reagendar el especialista.