### PR TITLE
Error al mostrar botón de justificación con citas de colaborador

### DIFF
--- a/application/controllers/CalendarioController.php
+++ b/application/controllers/CalendarioController.php
@@ -319,7 +319,7 @@ class CalendarioController extends BaseController{
 					if ($response['result']) {
                         $values = [
                             "titulo" => $titulo, "idEspecialista" => $idEspecialista,
-                            "idPaciente" => $idPaciente, "observaciones" => $observaciones,
+                            "idPaciente" => $idPaciente, "observaciones" => NULL,
                             "fechaInicio" => $fechaInicio, "fechaFinal" => $fechaFinal,
                             "tipoCita" => $tipoCita, "idAtencionXSede" => $idAtencionXSede,
                             "estatusCita" => $estatusCita, "creadoPor" => $idPaciente,


### PR DESCRIPTION
El botón de justificaciones no salía cuando la cita era agendada por el colaborador, esto debido a que el campo de observaciones se envía con string vació y el botón se desarrollo para que solo se visualizara cuando sea null.